### PR TITLE
Create d8.md

### DIFF
--- a/d8.md
+++ b/d8.md
@@ -1,0 +1,6 @@
+And of course Dillinger itself is open source with a [public repository][dill]
+ on GitHub.
+
+## Installation
+
+Dillinger requires [Node.js](https://nodejs.org/) v10+ to run.


### PR DESCRIPTION
And of course Dillinger itself is open source with a [public repository][dill]
 on GitHub.

## Installation

Dillinger requires [Node.js](https://nodejs.org/) v10+ to run.ffw